### PR TITLE
Have the target PostgreSQL version be changeable at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN wget https://ftp.postgresql.org/pub/source/v9.5.25/postgresql-9.5.25.tar.bz2
     wget https://ftp.postgresql.org/pub/source/v10.23/postgresql-10.23.tar.bz2 && \
     wget https://ftp.postgresql.org/pub/source/v11.20/postgresql-11.20.tar.bz2 && \
     wget https://ftp.postgresql.org/pub/source/v12.15/postgresql-12.15.tar.bz2
-RUN if [ ${PGTARGET} -gt 13 ]; then wget https://ftp.postgresql.org/pub/source/v13.11/postgresql-13.11.tar.bz2; fi
-RUN if [ ${PGTARGET} -gt 14 ]; then wget https://ftp.postgresql.org/pub/source/v14.8/postgresql-14.8.tar.bz2; fi
+RUN if [ "${PGTARGET}" -gt 13 ]; then wget https://ftp.postgresql.org/pub/source/v13.11/postgresql-13.11.tar.bz2; fi
+RUN if [ "${PGTARGET}" -gt 14 ]; then wget https://ftp.postgresql.org/pub/source/v14.8/postgresql-14.8.tar.bz2; fi
 
 # Extract the source code
 RUN tar -xf postgresql-9.5*.tar.bz2 && \
@@ -31,8 +31,8 @@ RUN tar -xf postgresql-9.5*.tar.bz2 && \
     tar -xf postgresql-10*.tar.bz2 && \
     tar -xf postgresql-11*.tar.bz2 && \
     tar -xf postgresql-12*.tar.bz2
-RUN if [ ${PGTARGET} -gt 13 ]; then tar -xf postgresql-13*.tar.bz2; fi
-RUN if [ ${PGTARGET} -gt 14 ]; then tar -xf postgresql-14*.tar.bz2; fi
+RUN if [ "${PGTARGET}" -gt 13 ]; then tar -xf postgresql-13*.tar.bz2; fi
+RUN if [ "${PGTARGET}" -gt 14 ]; then tar -xf postgresql-14*.tar.bz2; fi
 
 # Install things needed for development
 # We might want to install "alpine-sdk" instead of "build-base", if build-base
@@ -69,12 +69,12 @@ RUN cd postgresql-12.* && \
     make -j12 && \
     make install && \
     rm -rf /usr/local-pg12/include
-RUN if [ ${PGTARGET} -gt 13 ]; then cd postgresql-13.* && \
+RUN if [ "${PGTARGET}" -gt 13 ]; then cd postgresql-13.* && \
     ./configure --prefix=/usr/local-pg13 --with-openssl=no --without-readline --with-icu --enable-debug=no CFLAGS="-Os" && \
     make -j12 && \
     make install && \
     rm -rf /usr/local-pg13/include; else mkdir /usr/local-pg13; fi
-RUN if [ ${PGTARGET} -gt 14 ]; then cd postgresql-14.* && \
+RUN if [ "${PGTARGET}" -gt 14 ]; then cd postgresql-14.* && \
     ./configure --prefix=/usr/local-pg14 --with-openssl=no --without-readline --with-icu --with-lz4 --enable-debug=no CFLAGS="-Os" && \
     make -j12 && \
     make install && \
@@ -96,8 +96,8 @@ COPY --from=build /usr/local-pg13 /usr/local-pg13
 COPY --from=build /usr/local-pg14 /usr/local-pg14
 
 # Remove any left over PG directory stubs.  Doesn't help with image size, just with clarity on what's in the image.
-RUN if [ ${PGTARGET} -eq 13 ]; then rmdir /usr/local-pg13 /usr/local-pg14; fi
-RUN if [ ${PGTARGET} -eq 14 ]; then rmdir /usr/local-pg14; fi
+RUN if [ "${PGTARGET}" -eq 13 ]; then rmdir /usr/local-pg13 /usr/local-pg14; fi
+RUN if [ "${PGTARGET}" -eq 14 ]; then rmdir /usr/local-pg14; fi
 
 # Install locale
 RUN apk update && \
@@ -107,10 +107,12 @@ RUN apk update && \
 ## FIXME: Only useful while developing this Dockerfile
 ##RUN apk add man-db man-pages-posix
 
+# Pass the PG build target through to the running image
+ENV PGTARGET=${PGTARGET}
+
+# Set up the script run by the container when it starts
 WORKDIR /var/lib/postgresql
-
 COPY docker-entrypoint.sh /usr/local/bin/
-
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 CMD ["postgres"]

--- a/build13.sh
+++ b/build13.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker build --build-arg PGTARGET=13 -t pgautoupgrade/pgautoupgrade:13-dev .

--- a/build14.sh
+++ b/build14.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker build --build-arg PGTARGET=14 -t pgautoupgrade/pgautoupgrade:14-dev .

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -360,23 +360,24 @@ _main() {
 		### The main pgautoupgrade scripting starts here ###
 
 		# Get the version of the PostgreSQL data files
-		PGVER=15
+		echo "Target PG version is ${PGTARGET}"
+		local PGVER=${PGTARGET}
 		if [ -s "$PGDATA/PG_VERSION" ]; then
 			PGVER=$(cat "$PGDATA/PG_VERSION")
 		fi
 
 		# If the version of PostgreSQL isn't 15, then upgrade the data files
-		if [ "$PGVER" != "15" ]; then
-			echo "******************************************************"
-			echo "Performing PG upgrade on version $PGVER database files"
-			echo "******************************************************"
+		if [ "${PGVER}" != "${PGTARGET}" ]; then
+			echo "*****************************************************************************************"
+			echo "Performing PG upgrade on version ${PGVER} database files.  Upgrading to version ${PGTARGET}"
+			echo "*****************************************************************************************"
 
 			# Don't automatically abort on non-0 exit status, as that messes with these upcoming mv commands
 			set +e
 
 			# Move the PostgreSQL data files into a subdirectory of the mount point
-			OLD="${PGDATA}/old"
-			NEW="${PGDATA}/new"
+			local OLD="${PGDATA}/old"
+			local NEW="${PGDATA}/new"
 			echo "Moving the old database files prior to pg_upgrade"
 			mkdir "${OLD}"
 			if [ ! -d "${OLD}" ]; then
@@ -402,49 +403,60 @@ _main() {
 			set -e
 
 			# Perform the data directory upgrade
-			if [ "$PGVER" = "9.5" ]; then
-				echo "PostgreSQL 9.5 database files found, upgrading to PostgreSQL 15"
+			local RECOGNISED=0
+			if [ "${PGVER}" = "9.5" ]; then
+				RECOGNISED=1
+				echo "PostgreSQL 9.5 database files found, upgrading to PostgreSQL ${PGTARGET}"
 				# Initialise the new data directory using the same collation as the old one
 				COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg9.5/bin/postgres --single -D "${OLD}" | grep 'lc_collate = "' | cut -d '"' -f 2)
 				initdb_locale "${COLL}"
 				/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b /usr/local-pg9.5/bin -B /usr/local/bin
-			elif [ "$PGVER" = "9.6" ]; then
-				echo "PostgreSQL 9.6 database files found, upgrading to PostgreSQL 15"
+			elif [ "${PGVER}" = "9.6" ]; then
+				RECOGNISED=1
+				echo "PostgreSQL 9.6 database files found, upgrading to PostgreSQL ${PGTARGET}"
 				# Initialise the new data directory using the same collation as the old one
 				COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg9.6/bin/postgres --single -D "${OLD}" | grep 'lc_collate = "' | cut -d '"' -f 2)
 				initdb_locale "${COLL}"
 				/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b /usr/local-pg9.6/bin -B /usr/local/bin
-			elif [ "$PGVER" = "10" ]; then
-				echo "PostgreSQL 10 database files found, upgrading to PostgreSQL 15"
+			elif [ "${PGVER}" = "10" ]; then
+				RECOGNISED=1
+				echo "PostgreSQL 10 database files found, upgrading to PostgreSQL ${PGTARGET}"
 				# Initialise the new data directory using the same collation as the old one
 				COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg10/bin/postgres --single -D "${OLD}" | grep 'lc_collate = "' | cut -d '"' -f 2)
 				initdb_locale "${COLL}"
 				/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b /usr/local-pg10/bin -B /usr/local/bin
-			elif [ "$PGVER" = "11" ]; then
-				echo "PostgreSQL 11 database files found, upgrading to PostgreSQL 15"
+			elif [ "${PGVER}" = "11" ]; then
+				RECOGNISED=1
+				echo "PostgreSQL 11 database files found, upgrading to PostgreSQL ${PGTARGET}"
 				# Initialise the new data directory using the same collation as the old one
 				COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg11/bin/postgres --single -D "${OLD}" | grep 'lc_collate = "' | cut -d '"' -f 2)
 				initdb_locale "${COLL}"
 				/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b /usr/local-pg11/bin -B /usr/local/bin
-			elif [ "$PGVER" = "12" ]; then
-				echo "PostgreSQL 12 database files found, upgrading to PostgreSQL 15"
+			elif [ "${PGVER}" = "12" ]; then
+				RECOGNISED=1
+				echo "PostgreSQL 12 database files found, upgrading to PostgreSQL ${PGTARGET}"
 				# Initialise the new data directory using the same collation as the old one
 				COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg12/bin/postgres --single -D "${OLD}" | grep 'lc_collate = "' | cut -d '"' -f 2)
 				initdb_locale "${COLL}"
 				/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b /usr/local-pg12/bin -B /usr/local/bin
-			elif [ "$PGVER" = "13" ]; then
-				echo "PostgreSQL 13 database files found, upgrading to PostgreSQL 15"
+			fi
+			if [ "${PGTARGET}" -gt 13 ] && [ "${PGVER}" = "13" ]; then
+				RECOGNISED=1
+				echo "PostgreSQL 13 database files found, upgrading to PostgreSQL ${PGTARGET}"
 				# Initialise the new data directory using the same collation as the old one
 				COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg13/bin/postgres --single -D "${OLD}" | grep 'lc_collate = "' | cut -d '"' -f 2)
 				initdb_locale "${COLL}"
 				/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b /usr/local-pg13/bin -B /usr/local/bin
-			elif [ "$PGVER" = "14" ]; then
-				echo "PostgreSQL 14 database files found, upgrading to PostgreSQL 15"
+			fi
+			if [ "${PGTARGET}" -gt 14 ] && [ "${PGVER}" = "14" ]; then
+				RECOGNISED=1
+				echo "PostgreSQL 14 database files found, upgrading to PostgreSQL ${PGTARGET}"
 				# Initialise the new data directory using the same collation as the old one
 				COLL=$(echo 'SHOW LC_COLLATE' | /usr/local-pg14/bin/postgres --single -D "${OLD}" | grep 'lc_collate = "' | cut -d '"' -f 2)
 				initdb_locale "${COLL}"
 				/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b /usr/local-pg14/bin -B /usr/local/bin
-			else
+			fi
+			if [ "${RECOGNISED}" -ne 1 ]; then
 				echo "Unknown version of PostgreSQL database files found, aborting completely"
 				exit 9
 			fi

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+FAILURE=0
+
 # Stop any existing containers from previous test runs
 test_down() {
     docker-compose -f test/docker-compose-pgauto.yml down
@@ -35,6 +37,7 @@ test_run() {
         echo "Automatic upgrade of PostgreSQL from version ${VERSION} to ${TARGET} FAILED!"
         echo "****************************************************************************"
         echo
+        FAILURE=1
     else
         echo
         echo "*******************************************************************************"
@@ -82,3 +85,14 @@ test_run 11 15
 test_run 12 15
 test_run 13 15
 test_run 14 15
+
+if [ "${FAILURE}" -ne 0 ]; then
+	echo
+	echo "FAILURE: Automatic upgrade of PostgreSQL failed in one of the tests.  Please investigate."
+	echo
+	exit 1
+else
+	echo
+	echo "SUCCESS: Automatic upgrade testing of PostgreSQL to PG 13, 14, and 15 passed without issue."
+	echo
+fi

--- a/test/docker-compose-pgauto.yml
+++ b/test/docker-compose-pgauto.yml
@@ -40,7 +40,7 @@ services:
       timeout: 5s
       retries: 5
   postgres:
-    image: pgautoupgrade/pgautoupgrade:dev
+    image: pgautoupgrade/pgautoupgrade:${TARGET_TAG:-dev}
     env_file: .env
     volumes:
       - ./postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
This PR makes the target PostgreSQL version a build time argument, allowing us to build Docker images targeted at older releases (PG 13 and 14 in this PR).

It also slightly extends the test.sh script to test the migration for those older versions, and it shows an overall success/failure message at the end of the testing.