### PR TITLE
Use a Makefile instead of lots of shell scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.PHONY: all dev 13dev 14dev 15dev latest attach before clean down server test up
+
+all: 13dev 14dev 15dev latest
+
+dev: 15dev
+
+13dev:
+	docker build --build-arg PGTARGET=13 -t pgautoupgrade/pgautoupgrade:13-dev .
+
+14dev:
+	docker build --build-arg PGTARGET=14 -t pgautoupgrade/pgautoupgrade:14-dev .
+
+15dev:
+	docker build -t pgautoupgrade/pgautoupgrade:dev .
+
+latest:
+	docker build -t pgautoupgrade/pgautoupgrade:15-alpine3.8 -t pgautoupgrade/pgautoupgrade:latest .
+
+attach:
+	docker exec -it pgauto /bin/bash
+
+before:
+	if [ ! -d "test/postgres-data" ]; then mkdir test/postgres-data; fi && docker run --name pgauto -it --rm -e POSTGRES_PASSWORD=password --mount type=bind,source=$(abspath $(CURDIR))/test/postgres-data,target=/var/lib/postgresql/data -e PGAUTO_DEVEL=before pgautoupgrade/pgautoupgrade:dev
+
+clean:
+	docker image rm --force pgautoupgrade/pgautoupgrade:dev pgautoupgrade/pgautoupgrade:13-dev pgautoupgrade/pgautoupgrade:14-dev pgautoupgrade/pgautoupgrade:15-alpine3.8 pgautoupgrade/pgautoupgrade:latest && \
+	docker image prune -f && \
+	docker volume prune -f
+
+down:
+	./test.sh down
+
+server:
+	if [ ! -d "test/postgres-data" ]; then mkdir test/postgres-data; fi && docker run --name pgauto -it --rm -e POSTGRES_PASSWORD=password --mount type=bind,source=$(abspath $(CURDIR))/test/postgres-data,target=/var/lib/postgresql/data -e PGAUTO_DEVEL=server pgautoupgrade/pgautoupgrade:dev
+
+test:
+	./test.sh
+
+up:
+	if [ ! -d "test/postgres-data" ]; then mkdir test/postgres-data; fi && docker run --name pgauto -it --rm -e POSTGRES_PASSWORD=password --mount type=bind,source=$(abspath $(CURDIR))/test/postgres-data,target=/var/lib/postgresql/data pgautoupgrade/pgautoupgrade:dev

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ part of the script runs, so you can try alternative things
 instead.
 
 ```
-$ ./run.sh -e PGAUTO_DEVEL=before
+$ make before
 ```
 
 ### Server breakpoint
@@ -80,7 +80,7 @@ if you want to investigate the results of the upgrade prior to
 PostgreSQL acting on them.
 
 ```
-$ ./run.sh -e PGAUTO_DEVEL=server
+$ make server
 ```
 
 ## Testing the container image
@@ -88,7 +88,7 @@ $ ./run.sh -e PGAUTO_DEVEL=server
 To run the tests, use:
 
 ```
-$ ./test.sh
+$ make test
 ```
 
 The test script creates an initial PostgreSQL database for

--- a/attach.sh
+++ b/attach.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker exec -it pgauto /bin/bash

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker build -t pgautoupgrade/pgautoupgrade:latest .

--- a/build13.sh
+++ b/build13.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker build --build-arg PGTARGET=13 -t pgautoupgrade/pgautoupgrade:13-dev .

--- a/build14.sh
+++ b/build14.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker build --build-arg PGTARGET=14 -t pgautoupgrade/pgautoupgrade:14-dev .

--- a/rm.sh
+++ b/rm.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker image rm pgautoupgrade/pgautoupgrade:dev

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-if [ ! -d "test/postgres-data" ]; then
-  mkdir test/postgres-data
-fi
-
-# Start the docker container 
-docker run --name pgauto -it --rm -e POSTGRES_PASSWORD=password --mount type=bind,source=$(pwd)/test/postgres-data,target=/var/lib/postgresql/data $@ pgautoupgrade/pgautoupgrade:dev


### PR DESCRIPTION
The repo was starting to get fairly messy due to having shell scripts for everything.

This PR removes all but the `test.sh` shell script, replacing them with various Makefile targets.