### PR TITLE
More automated tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,14 @@ jobs:
           push: true
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"
+
+      - name: Push latest image
+        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main' && matrix.pg_target == '16'
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            "pgautoupgrade/pgautoupgrade:latest"
+          push: true
+          cache-to: type=inline
+          cache-from: "${{ env.CACHE_FROM }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     env:
       # but still use our public caches in any case
       # they might be outdated, in which case a full rebuild will be triggered
-      TARGET_TAG: ${{ github.ref == 'refs/heads/main' && 'alpine3.19' || 'dev-alpine3.19' }}
+      TARGET_TAG: ${{ github.ref == 'refs/heads/main' && 'alpine' || 'dev-alpine' }}
       CACHE_FROM: |
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-9.5
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-9.6
@@ -68,6 +68,7 @@ jobs:
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-14
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-15
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-16
+        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine
         type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine3.19
       # we cannot access TARGET_TAG from env
       # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
@@ -99,7 +100,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           load: true
-          tags: "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine3.19"
+          tags: |
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine"
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine3.19"
           build-args: |
             "PGTARGET=${{ matrix.pg_target }}"
           cache-to: type=inline
@@ -119,7 +122,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           platforms: linux/amd64,linux/arm64
-          tags: "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ env.TARGET_TAG }}"
+          tags: |
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine"
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine3.19"
           push: true
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ To always use the latest version of PostgreSQL, use the tag
     pgautoupgrade/pgautoupgrade:latest
 
 If you instead want to run a specific version of PostgreSQL
-then pick a matching tag on our Docker Hub.  For example, to
+then pick a matching tag on our Docker Hub. For example, to
 use PostgreSQL 15 you can use:
 
-    pgautoupgrade/pgautoupgrade:15-alpine3.19
+    pgautoupgrade/pgautoupgrade:15-alpine
 
 ### "One shot" mode
 

--- a/test.sh
+++ b/test.sh
@@ -25,7 +25,7 @@ test_run() {
     docker compose -f "docker-compose-pg${VERSION}.yml" run --rm server create_db
 
     # Start Redash normally, using an "autoupdate" version of PostgreSQL
-    TARGET_TAG="${TARGET}-alpine3.19" docker compose -f docker-compose-pgauto.yml up --wait -d
+    TARGET_TAG="${TARGET}-alpine" docker compose -f docker-compose-pgauto.yml up --wait -d
 
     # Verify the PostgreSQL data files are now the target version
     PGVER=$(sudo cat postgres-data/PG_VERSION)


### PR DESCRIPTION
After looking at the recent pipeline run on main as well as the built images on Docker Hub, I think the pipeline is doing what it should do.

This PR adds more tags which are automatically built:

- `12-alpine`, `13-alpine`, `14-alpine`, `15-alpine` and `16-alpine`.
- `latest`, which is the same as `16-alpine3.19` (I hope this will work as intended).