### PR TITLE
Add missing `PGTARGET` environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine"
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-alpine3.19"
+          build-args: |
+            "PGTARGET=${{ matrix.pg_target }}"
           push: true
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"
@@ -136,6 +138,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:latest"
+          build-args: |
+            "PGTARGET=${{ matrix.pg_target }}"
           push: true
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"


### PR DESCRIPTION
Fixes #28.

This PR adds the missing `PGTARGET` variable to the push job, which caused all images to infer v16 as their target version. this was not catched during the tests since those images had the build argument set correctly.