### PR TITLE
Use socketdir with pg_upgrade command for macOS ARM support

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -518,7 +518,7 @@ _main() {
 			echo "---------------------------------------"
 			echo "Running pg_upgrade command, from $(pwd)"
 			echo "---------------------------------------"
-			/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b "${OLDPATH}/bin" -B /usr/local/bin
+			/usr/local/bin/pg_upgrade --username="${POSTGRES_USER}" --link -d "${OLD}" -D "${NEW}" -b "${OLDPATH}/bin" -B /usr/local/bin --socketdir="/var/run/postgresql"
 			echo "--------------------------------------"
 			echo "Running pg_upgrade command is complete"
 			echo "--------------------------------------"


### PR DESCRIPTION
This PR adds the `--socketdir` option to the `pg_upgrade` command, which allows it to run correctly on macOS ARM64 and seems to work without problem on other platforms too.

Thanks to @gav-fyi for figuring this out. :)