### PR TITLE
Delete Postgres image if running on CI

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -47,6 +47,11 @@ test_run() {
 
     # Shut down containers from previous test runs
     docker compose -f docker-compose-pgauto.yml down
+
+    # If running on CI, delete the Postgres Docker image to avoid space problems
+    if [ -n "$CI" ]; then
+        docker rmi -f $(docker images postgres -q)
+    fi
 }
 
 # Shut down containers from previous test runs


### PR DESCRIPTION
We run into space problem on CI when running the tests for newer Postgres version with the new Debian image. This PR amends the tests to delete the Postgres images when running on CI.