### PR TITLE
Cleanup Docker images before pushing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,15 @@ jobs:
           PGTARGET: ${{ matrix.pg_target }}
           OS_FLAVOR: ${{ matrix.operating_system.flavor }}
 
+      # otherwise, we run into space problems
+      # from observation, the buildx builder container already occupies 7 GB out of the 14 GB we have available on a GitHub Actions runner
+      # note that this command will also destroy the pgautoupgrade image we just build
+      # which is intentional, the buildx builder should contain all information still to re-create the same image
+      - name: Cleanup Docker image before pushing
+        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main'
+        run: |
+          docker image prune -a
+
       - name: Push image
         if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v5


### PR DESCRIPTION
I debugged the space issue we see on `main` before pushing the final images. You can see the result in this workflow run: https://github.com/pgautoupgrade/docker-pgautoupgrade/actions/runs/10338675065/job/28617075730.

First, the GitHub Runner seems to have cached a couple of images:

```
pgautoupgrade/pgautoupgrade   14-alpine         60f7bd353870   4 minutes ago   576MB
pgautoupgrade/pgautoupgrade   14-alpine3.20     60f7bd353870   4 minutes ago   576MB
redis                         7-alpine          da7b3f96549f   13 days ago     41.2MB
moby/buildkit                 buildx-stable-1   f836cfaa6d36   2 weeks ago     202MB
moby/buildkit                 latest            f836cfaa6d36   2 weeks ago     202MB
node                          20                1a8e51cfa7a5   2 weeks ago     1.1GB
node                          20-alpine         e2997a3fdff8   2 weeks ago     133MB
debian                        11                91a3af22c9b3   2 weeks ago     124MB
alpine                        3.17              91dce2778e2d   2 weeks ago     7.08MB
alpine                        3.18              18f865063206   2 weeks ago     7.35MB
alpine                        3.19              494edff73605   2 weeks ago     7.39MB
node                          18                15babc4ad7bd   4 weeks ago     1.09GB
node                          18-alpine         e64c650c0cf3   4 weeks ago     128MB
ubuntu                        22.04             8a3cdc4d1ad3   6 weeks ago     77.9MB
debian                        10                69530eaa9e7e   8 weeks ago     115MB
ubuntu                        20.04             5f5250218d28   2 months ago    72.8MB
alpine                        3.16              d49a5025be10   6 months ago    5.54MB
node                          16                1ddc7e4055fd   11 months ago   909MB
node                          16-alpine         2573171e0124   12 months ago   118MB
tonistiigi/binfmt             latest            354472a37893   2 years ago     60.2MB
redash/redash                 10.1.0.b50633     19b4394daf76   2 years ago     1.37GB
```

we now remove all unused images prior to pushing new images.

the other thing I noted is that the `buildx` instance gets quite large:

```
6758728	/var/lib/docker/volumes/buildx_buildkit_builder-785a154f-68c4-4894-8852-4000baf1f2de0_state/_data/runc-overlayfs
```

I can only guess what is happening in there. likely it pulls all base images in order to put together the requested target image, plus caching of the images we just build. so even if we remove the `pgautoupgrade` image that was just built, it should recreate an identical one.