### PR TITLE
Provide image for v17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           - "14"
           - "15"
           - "16"
+          - "17"
 
     steps:
       - name: Set up QEMU

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -402,6 +402,9 @@ _main() {
 			if [ "${PGTARGET}" -gt 15 ] && [ "${PGVER}" = "15" ]; then
 				RECOGNISED=1
 			fi
+			if [ "${PGTARGET}" -gt 16 ] && [ "${PGVER}" = "16" ]; then
+				RECOGNISED=1
+			fi
 			if [ "${RECOGNISED}" -eq 1 ]; then
 				OLDPATH="/usr/local-pg${PGVER}"
 				echo "*******************************************************************************************"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -319,13 +319,7 @@ _main() {
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
-			if [ -f /etc/alpine-release ]; then
-				# If running on Alpine, use su-exec
-				exec su-exec postgres "$BASH_SOURCE" "$@"
-			else
-				# Otherwise, use gosu
-				exec gosu postgres "$BASH_SOURCE" "$@"
-			fi
+			exec gosu postgres "$BASH_SOURCE" "$@"
 		fi
 
 		# only run initialization on an empty data directory

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -504,10 +504,20 @@ _main() {
 				local COLLATE=unset
 				local CTYPE=unset
 				local ENCODING=unset
-				COLLATE=$(echo 'SHOW LC_COLLATE' | "${OLDPATH}/bin/postgres" --single -D "${OLD}" "${POSTGRES_DB}" | grep 'lc_collate = "' | cut -d '"' -f 2)
-				CTYPE=$(echo 'SHOW LC_CTYPE' | "${OLDPATH}/bin/postgres" --single -D "${OLD}" "${POSTGRES_DB}" | grep 'lc_ctype = "' | cut -d '"' -f 2)
+
 				ENCODING=$(echo 'SHOW SERVER_ENCODING' | "${OLDPATH}/bin/postgres" --single -D "${OLD}" "${POSTGRES_DB}" | grep 'server_encoding = "' | cut -d '"' -f 2)
-				POSTGRES_INITDB_ARGS="--locale=${COLLATE} --lc-collate=${COLLATE} --lc-ctype=${CTYPE} --encoding=${ENCODING}"
+
+				# LC_COLLATE and LC_TYPE have been removed with PG v16
+				# https://www.postgresql.org/docs/release/16.0/
+				if [ "${PGVER}" -lt 16 ]; then
+					COLLATE=$(echo 'SHOW LC_COLLATE' | "${OLDPATH}/bin/postgres" --single -D "${OLD}" "${POSTGRES_DB}" | grep 'lc_collate = "' | cut -d '"' -f 2)
+					CTYPE=$(echo 'SHOW LC_CTYPE' | "${OLDPATH}/bin/postgres" --single -D "${OLD}" "${POSTGRES_DB}" | grep 'lc_ctype = "' | cut -d '"' -f 2)
+
+					POSTGRES_INITDB_ARGS="--locale=${COLLATE} --lc-collate=${COLLATE} --lc-ctype=${CTYPE} --encoding=${ENCODING}"
+				else
+					POSTGRES_INITDB_ARGS="--encoding=${ENCODING}"
+				fi
+
 				echo "---------------------------------------------------------------"
 				echo "The initdb arguments we determined are: ${POSTGRES_INITDB_ARGS}"
 				echo "---------------------------------------------------------------"

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -eux
 FAILURE=0
 
 # Array of PostgreSQL versions for testing
-PG_VERSIONS=(9.5 9.6 10 11 12 13 14 15 16)
+PG_VERSIONS=(9.5 9.6 10 11 12 13 14 15 16 17)
 
 # Stop any existing containers from previous test runs
 test_down() {

--- a/test/docker-compose-pg16.yml
+++ b/test/docker-compose-pg16.yml
@@ -1,0 +1,58 @@
+version: "2.1"
+x-redash-service: &redash-service
+  image: redash/redash:10.1.0.b50633
+  depends_on:
+    redis:
+      condition: service_healthy
+    postgres:
+      condition: service_healthy
+  env_file: .env
+  restart: always
+services:
+  server:
+    <<: *redash-service
+    command: server
+    ports:
+      - "127.0.0.1:5000:5000"
+    environment:
+      REDASH_WEB_WORKERS: 22
+  scheduler:
+    <<: *redash-service
+    command: scheduler
+  scheduled_worker:
+    <<: *redash-service
+    command: worker
+    environment:
+      QUEUES: "scheduled_queries,schemas"
+      WORKERS_COUNT: 2
+  adhoc_worker:
+    <<: *redash-service
+    command: worker
+    environment:
+      QUEUES: "queries"
+      WORKERS_COUNT: 2
+  redis:
+    image: redis:7-alpine
+    restart: always
+    healthcheck:
+      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  postgres:
+    image: postgres:16-alpine
+    env_file: .env
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  worker:
+    <<: *redash-service
+    command: worker
+    environment:
+      QUEUES: "periodic emails default"
+      WORKERS_COUNT: 2


### PR DESCRIPTION
This PR provides a new image for Postgres v17.

@justinclift from what I've seen in the code, we actually do not have to provide a new `build-17` build stage, since we only need to compile Postgres when upgrading from that version. Since we do not need to upgrade from v17 at the moment, this is not needed.

Closes #47.