### PR TITLE
Don't hard code the `postgres` database name

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -595,7 +595,7 @@ _main() {
 	else
 		# If the upgrade process ran, then we need to launch the post-upgrade script in the background while PG runs
 		if [ "${UPGRADE_PERFORMED}" -eq 1 ]; then
-			/usr/local/bin/pgautoupgrade-postupgrade.sh "${PGDATA}" "${PGAUTO_ONESHOT}" 2>&1 &
+			/usr/local/bin/pgautoupgrade-postupgrade.sh "${PGDATA}" "${POSTGRES_DB}" "${PGAUTO_ONESHOT}" 2>&1 &
 			echo "****************************"
 			echo "Post upgrade script launched"
 			echo "****************************"

--- a/pgautoupgrade-postupgrade.sh
+++ b/pgautoupgrade-postupgrade.sh
@@ -2,13 +2,14 @@
 
 set -e
 
-if [ $# -ne 2 ]; then
-	echo "Required number of arguments not passed to post upgrade script.  2 expected, $# received"
+if [ $# -ne 3 ]; then
+	echo "Required number of arguments not passed to post upgrade script.  3 expected, $# received"
 	exit 1
 fi
 
 PGDATA=$1
-PGAUTO_ONESHOT=$2
+POSTGRES_DB=$2
+PGAUTO_ONESHOT=$3
 
 # Wait for PostgreSQL to start and become available
 COUNT=0
@@ -37,7 +38,7 @@ if [ $RUNNING -ne 0 ]; then
 fi
 
 # Get the list of databases in the database cluster
-DB_LIST=$(echo 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate IS FALSE' | psql -1t --csv postgres)
+DB_LIST=$(echo 'SELECT datname FROM pg_catalog.pg_database WHERE datistemplate IS FALSE' | psql -1t --csv "${POSTGRES_DB}")
 
 # Update query planner statistics
 echo "----------------------------"


### PR DESCRIPTION
This PR is a follow up for #50, which included a hard coded use of the database `postgres`.

Instead of doing that we re-use the name of the database used by the main docker entrypoint script.