### PR TITLE
Test pgautoupgrade container using AdventureWorks database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 pgstuff
 test/postgres-data
 .idea
+
+test/AdventureWorks.sql
+test/AdventureWorks.tar.xz

--- a/README.md
+++ b/README.md
@@ -133,15 +133,14 @@ To run the tests, use:
 $ make test
 ```
 
-The test script creates an initial PostgreSQL database for
-Redash using an older PG version, then starts Redash using
-the above "automatic updating" PostgreSQL image to update
-the database to the latest PostgreSQL version.
+The test script imports the AdventureWorks database (ported from Microsoft
+land) into an older PG version, then starts the pgautoupgrade container to
+update the database to the latest PostgreSQL version.
 
 It then checks that the database files were indeed updated
 to the newest PostgreSQL release, and outputs an obvious
 SUCCESS/FAILURE message for that loop.
 
 The test runs in a loop, testing (in sequence) upgrades from
-PostgreSQL versions 9.5, 9.6, 10.x, 11.x, 12.x, 13.x, 14.x
-and 15.x.
+PostgreSQL versions 9.5, 9.6, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x., 16.x and
+17.x.

--- a/test/.env
+++ b/test/.env
@@ -1,8 +1,2 @@
 # The values below are useful for testing this repo with
-#REDASH_LOG_LEVEL=INFO
-REDASH_COOKIE_SECRET=HKuj2aZx7vRQXghnegXY0tDZWPS493F5
-REDASH_SECRET_KEY=SHGVxI1Yecfz9k7xjwMnF0hCtwh04dFk
-PYTHONUNBUFFERED=0
-REDASH_REDIS_URL=redis://redis:6379/0
 POSTGRES_PASSWORD=FmTKs5vX52ufKR1rd8tn4MoSP7zvCJwb
-REDASH_DATABASE_URL=postgresql://postgres:FmTKs5vX52ufKR1rd8tn4MoSP7zvCJwb@postgres/postgres

--- a/test/docker-compose-pg10.yml
+++ b/test/docker-compose-pg10.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:10-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg11.yml
+++ b/test/docker-compose-pg11.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:11-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg12.yml
+++ b/test/docker-compose-pg12.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:12-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg13.yml
+++ b/test/docker-compose-pg13.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:13-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg14.yml
+++ b/test/docker-compose-pg14.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:14-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg15.yml
+++ b/test/docker-compose-pg15.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:15-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg16.yml
+++ b/test/docker-compose-pg16.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:16-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg9.5.yml
+++ b/test/docker-compose-pg9.5.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:9.5-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pg9.6.yml
+++ b/test/docker-compose-pg9.6.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: postgres:9.6-alpine
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2

--- a/test/docker-compose-pgauto.yml
+++ b/test/docker-compose-pgauto.yml
@@ -1,43 +1,4 @@
-x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
-  depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  env_file: .env
-  restart: always
 services:
-  server:
-    <<: *redash-service
-    command: server
-    ports:
-      - "127.0.0.1:5000:5000"
-    environment:
-      REDASH_WEB_WORKERS: 22
-  scheduler:
-    <<: *redash-service
-    command: scheduler
-  scheduled_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "scheduled_queries,schemas"
-      WORKERS_COUNT: 2
-  adhoc_worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "queries"
-      WORKERS_COUNT: 2
-  redis:
-    image: redis:7-alpine
-    restart: always
-    healthcheck:
-      test: redis-cli -h 127.0.0.1 ping | grep -q PONG
-      interval: 10s
-      timeout: 5s
-      retries: 5
   postgres:
     image: pgautoupgrade/pgautoupgrade:${TARGET_TAG:-dev}
     env_file: .env
@@ -49,9 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  worker:
-    <<: *redash-service
-    command: worker
-    environment:
-      QUEUES: "periodic emails default"
-      WORKERS_COUNT: 2


### PR DESCRIPTION
This PR replaces the Redash service in the testing process with the `AdventureWorks` database from [here](https://github.com/pgautoupgrade/AdventureWorks-for-Postgres). Goal is that our upgrade script actually has some work to do compared to the previous iteration, helping us to spot errors.

There is room to add some example queries in the process (e.g. do some `COUNT` or `SELECT` against one or the other table) and check its result, but I think for now this change is good enough.