### PR TITLE
Option to skip reindexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ $ docker run --name pgauto -it \
 	<NAME_OF_THE_PGAUTOUPGRADE_IMAGE>
 ```
 
+### Skip reindexing
+
+By default, all databases are reindexed after the migration, which can take some time if they are large.
+To skip reindexing, set the environment variable `PGAUTO_REINDEX` to `no`, for example:
+
+```
+$ docker run --name pgauto -it \
+	--mount type=bind,source=/path/to/your/database/directory,target=/var/lib/postgresql/data \
+	-e POSTGRES_PASSWORD=password \
+	-e PGAUTO_REINDEX=no \
+	<NAME_OF_THE_PGAUTOUPGRADE_IMAGE>
+```
+
 # For Developers
 
 ## Building the image

--- a/pgautoupgrade-postupgrade.sh
+++ b/pgautoupgrade-postupgrade.sh
@@ -53,27 +53,29 @@ echo "-------------------------------------"
 echo "Finished updating query planner stats"
 echo "-------------------------------------"
 
-# Reindex the databases
-echo "------------------------"
-echo "Reindexing the databases"
-echo "------------------------"
-
-# For each database, reindex it
-for DATABASE in ${DB_LIST}; do
-	echo "-------------------------------"
-	echo "Starting reindex of ${DATABASE}"
-	echo "-------------------------------"
-
-	echo 'REINDEX DATABASE CONCURRENTLY' | psql --username="${POSTGRES_USER}" -t --csv "${DATABASE}"
-
-	echo "-------------------------------"
-	echo "Finished reindex of ${DATABASE}"
-	echo "-------------------------------"
-done
-
-echo "-------------------------------"
-echo "End of reindexing the databases"
-echo "-------------------------------"
+if [ "x${PGAUTO_REINDEX}" != "xno" ]; then
+        # Reindex the databases
+        echo "------------------------"
+        echo "Reindexing the databases"
+        echo "------------------------"
+        
+        # For each database, reindex it
+        for DATABASE in ${DB_LIST}; do
+        	echo "-------------------------------"
+        	echo "Starting reindex of ${DATABASE}"
+        	echo "-------------------------------"
+        
+        	echo 'REINDEX DATABASE CONCURRENTLY' | psql --username="${POSTGRES_USER}" -t --csv "${DATABASE}"
+        
+        	echo "-------------------------------"
+        	echo "Finished reindex of ${DATABASE}"
+        	echo "-------------------------------"
+        done
+        
+        echo "-------------------------------"
+        echo "End of reindexing the databases"
+        echo "-------------------------------"
+fi
 
 # If "one shot" mode was requested, then shut down PostgreSQL
 if [ "x${PGAUTO_ONESHOT}" = "xyes" ]; then


### PR DESCRIPTION
If the databases are huge, reindexing might take hours, so add an option to optionally skip it.