### PR TITLE
Improve Renovate configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
     - cron: "0 0 * * 0"
 
 env:
-  # renovate: datasource=docker depName=alpine versioning=docker
-  ALPINE_VERSION: "3.20"
   LATEST_POSTGRES_VERSION: "17"
 
 jobs:
@@ -77,13 +75,14 @@ jobs:
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-15-${{ matrix.operating_system.flavor }}
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-16-${{ matrix.operating_system.flavor }}
         type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}
-        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.version }}
+        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}
 
     strategy:
       matrix:
         operating_system:
           - flavor: "alpine"
-            version: "${{ env.ALPINE_VERSION }}"
+            # renovate: datasource=docker depName=alpine versioning=docker
+            OS_VERSION: "3.20"
           - flavor: "bookworm"
         pg_target:
           - "12"
@@ -114,7 +113,7 @@ jobs:
           load: true
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.version }}"
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
           build-args: |
             "PGTARGET=${{ matrix.pg_target }}"
           cache-to: type=inline
@@ -147,7 +146,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.version }}"
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
           build-args: |
             "PGTARGET=${{ matrix.pg_target }}"
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     - cron: "0 0 * * 0"
 
 env:
+  # renovate: datasource=docker depName=alpine versioning=docker
+  ALPINE_VERSION: "3.20"
   LATEST_POSTGRES_VERSION: "17"
 
 jobs:
@@ -81,7 +83,7 @@ jobs:
       matrix:
         operating_system:
           - flavor: "alpine"
-            version: "3.20"
+            version: "${{ env.ALPINE_VERSION }}"
           - flavor: "bookworm"
         pg_target:
           - "12"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,19 +9,19 @@ ENV PG96=9.6.24
 ENV PG10=10.23
 ENV PG11=11.22
 
-# renovate: datasource=repology depName=macports/postgresql12-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@12 versioning=loose
 ENV PG12_VERSION=12.22
 
-# renovate: datasource=repology depName=macports/postgresql13-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@13 versioning=loose
 ENV PG13_VERSION=13.18
 
-# renovate: datasource=repology depName=macports/postgresql14-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@14 versioning=loose
 ENV PG14_VERSION=14.15
 
-# renovate: datasource=repology depName=macports/postgresql15-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@15 versioning=loose
 ENV PG15_VERSION=15.10
 
-# renovate: datasource=repology depName=macports/postgresql16-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@16 versioning=loose
 ENV PG16_VERSION=16.6
 
 # Where we'll do all our compiling and similar

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,10 @@
 ARG PGTARGET=17
 
+# renovate: datasource=docker depName=alpine versioning=loose
+ARG ALPINE_VERSION=3.20
+
 ### Things we need in all build containers
-FROM alpine:3.20 AS base-build
+FROM alpine:${ALPINE_VERSION} AS base-build
 
 # The versions of PostgreSQL to use
 ENV PG95=9.5.25
@@ -145,7 +148,7 @@ RUN cd postgresql-16.* && \
   rm -rf /usr/local-pg16/include
 
 # Use the PostgreSQL Alpine image as our output image base
-FROM postgres:${PGTARGET}-alpine3.20
+FROM postgres:${PGTARGET}-alpine${ALPINE_VERSION}
 
 # We need to define this here, to make the above PGTARGET available after the FROM
 ARG PGTARGET

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -9,19 +9,19 @@ ENV PG96=9.6.24
 ENV PG10=10.23
 ENV PG11=11.22
 
-# renovate: datasource=repology depName=macports/postgresql12-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@12 versioning=loose
 ENV PG12_VERSION=12.22
 
-# renovate: datasource=repology depName=macports/postgresql13-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@13 versioning=loose
 ENV PG13_VERSION=13.18
 
-# renovate: datasource=repology depName=macports/postgresql14-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@14 versioning=loose
 ENV PG14_VERSION=14.15
 
-# renovate: datasource=repology depName=macports/postgresql15-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@15 versioning=loose
 ENV PG15_VERSION=15.10
 
-# renovate: datasource=repology depName=macports/postgresql16-server versioning=loose
+# renovate: datasource=repology depName=homebrew/postgresql@16 versioning=loose
 ENV PG16_VERSION=16.6
 
 # Where we'll do all our compiling and similar

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "customManagers:dockerfileVersions"
+    "customManagers:dockerfileVersions",
+    "customManagers:githubActionsVersions"
   ]
 }


### PR DESCRIPTION
This PR should solve a couple of issues with our Renovate configuration.

- Use Homebrew as the source for the different Postgres version. Macports still did not update all their versions, and Homebrew has done it basically on release day for the new PG versions.
- Track the `alpine` version in the Dockerfile to ensure that we also use the Alpine version for the final Docker images.
- Similarly, track the `alpine` version in the GitHub Actions file to ensure the tag will be correct.

I tested the changes on my personal fork of the repository, looks like it does what it should:

- https://github.com/andyundso/docker-pgautoupgrade/issues/3
- https://github.com/andyundso/docker-pgautoupgrade/pull/10