### PR TITLE
Build additional tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
             # renovate: datasource=docker depName=alpine versioning=docker
             OS_VERSION: "3.21"
           - flavor: "bookworm"
+            alias: "debian"
         pg_target:
           - "12"
           - "13"
@@ -114,6 +115,7 @@ jobs:
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.alias }}"
           build-args: |
             "PGTARGET=${{ matrix.pg_target }}"
           cache-to: type=inline
@@ -147,6 +149,7 @@ jobs:
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
+            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.alias }}"
           build-args: |
             "PGTARGET=${{ matrix.pg_target }}"
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,22 @@ jobs:
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"
 
-      - name: Push latest image
+      - name: Push latest image for each supported OS
+        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main' && matrix.pg_target == env.LATEST_POSTGRES_VERSION
+        uses: docker/build-push-action@v6
+        with:
+          file: "Dockerfile.${{ matrix.operating_system.flavor }}"
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.flavor }}"
+            "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.alias }}"
+          build-args: |
+            "PGTARGET=${{ matrix.pg_target }}"
+          push: true
+          cache-to: type=inline
+          cache-from: "${{ env.CACHE_FROM }}"
+
+      - name: Push general latest image
         if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main' && matrix.pg_target == env.LATEST_POSTGRES_VERSION && matrix.operating_system.flavor == 'alpine'
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Closes #79

As requested, this PR builds additional, more "general" tags:

* `<pg_version>-debian`: Specific PG version, latest Debian. For now this is `bookworm`, will become `trixie` in Summer 2025.
* `debian`: Latest PG version, latest Debian version.
* `alpine`: Latest PG version, latest Alpine version.

It is a bit hard to test if this works as intended, as the build and pushes are only triggered on main. Once approved, I can be around, merge this and observe the pipeline just in case.