### PR TITLE
Define "alias" for Alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           - flavor: "alpine"
             # renovate: datasource=docker depName=alpine versioning=docker
             OS_VERSION: "3.21"
+            alias: "debian"
           - flavor: "bookworm"
             alias: "debian"
         pg_target:


### PR DESCRIPTION
The pipeline currently fails on main since "alias" in the GitHub Actions matrix for the Alpine build resolves to nothing. By providing this, although identical to "flavor", it should be fixed.