### PR TITLE
Run ARM build on ARM machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,11 @@ jobs:
   base-images:
     # for security reason, we only build these images in our repository and on the main branch
     if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        runner_image:
+          - "ubuntu-24.04"
+          - "ubuntu-24.04-arm"
         flavor:
           - alpine
           - bookworm
@@ -29,11 +31,9 @@ jobs:
           - "14"
           - "15"
           - "16"
+    runs-on: "${{ matrix.runner_image }}"
 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,7 +48,6 @@ jobs:
         with:
           file: "Dockerfile.${{ matrix.flavor }}"
           push: true
-          platforms: linux/amd64,linux/arm64
           build-args: |
             "PGTARGET=16"
           target: "build-${{ matrix.pg_version }}"
@@ -57,7 +56,6 @@ jobs:
           cache-from: type=registry,ref=pgautoupgrade/pgautoupgrade:build-${{ matrix.pg_version }}-${{ matrix.flavor }}
 
   target-images:
-    runs-on: ubuntu-latest
     needs: base-images
     # otherwise, it would skip the build entirely (because the base step does not run)
     if: always()
@@ -80,6 +78,9 @@ jobs:
 
     strategy:
       matrix:
+        runner_image:
+          - "ubuntu-24.04"
+          - "ubuntu-24.04-arm"
         operating_system:
           - flavor: "alpine"
             # renovate: datasource=docker depName=alpine versioning=docker
@@ -94,11 +95,9 @@ jobs:
           - "15"
           - "16"
           - "17"
+    runs-on: "${{ matrix.runner_image }}"
 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -147,7 +146,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
-          platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
@@ -163,7 +161,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
-          platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.flavor }}"
             "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.alias }}"
@@ -178,7 +175,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
-          platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:latest"
           build-args: |


### PR DESCRIPTION
Closes #88 

With this PR, we run the AMD64 and ARM64 on separate machines, using the new public ARM runners by GitHub.