### PR TITLE
Disable `fail-fast`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - "14"
           - "15"
           - "16"
+      fail-fast: false
     runs-on: "${{ matrix.runner_image }}"
 
     steps:
@@ -95,6 +96,7 @@ jobs:
           - "15"
           - "16"
           - "17"
+      fail-fast: false
     runs-on: "${{ matrix.runner_image }}"
 
     steps:


### PR DESCRIPTION
Relates to #88.

The ARM runners seem to not work sometimes, resulting in the entire build being cancelled. By disabling `fail-fast`, the "good" jobs can continue to run, and we just restart the couple of jobs that failed for whatever reason.