### PR TITLE
Revert ARM changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
   base-images:
     # for security reason, we only build these images in our repository and on the main branch
     if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        runner_image:
-          - "ubuntu-24.04"
-          - "ubuntu-24.04-arm"
         flavor:
           - alpine
           - bookworm
@@ -31,9 +29,11 @@ jobs:
           - "14"
           - "15"
           - "16"
-    runs-on: "${{ matrix.runner_image }}"
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,6 +48,7 @@ jobs:
         with:
           file: "Dockerfile.${{ matrix.flavor }}"
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             "PGTARGET=16"
           target: "build-${{ matrix.pg_version }}"
@@ -56,6 +57,7 @@ jobs:
           cache-from: type=registry,ref=pgautoupgrade/pgautoupgrade:build-${{ matrix.pg_version }}-${{ matrix.flavor }}
 
   target-images:
+    runs-on: ubuntu-latest
     needs: base-images
     # otherwise, it would skip the build entirely (because the base step does not run)
     if: always()
@@ -78,9 +80,6 @@ jobs:
 
     strategy:
       matrix:
-        runner_image:
-          - "ubuntu-24.04"
-          - "ubuntu-24.04-arm"
         operating_system:
           - flavor: "alpine"
             # renovate: datasource=docker depName=alpine versioning=docker
@@ -95,9 +94,11 @@ jobs:
           - "15"
           - "16"
           - "17"
-    runs-on: "${{ matrix.runner_image }}"
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -146,6 +147,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
+          platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
             "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
@@ -161,6 +163,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
+          platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.flavor }}"
             "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.alias }}"
@@ -175,6 +178,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
+          platforms: linux/amd64,linux/arm64
           tags: |
             "pgautoupgrade/pgautoupgrade:latest"
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           - "14"
           - "15"
           - "16"
-      fail-fast: false
     runs-on: "${{ matrix.runner_image }}"
 
     steps:
@@ -96,7 +95,6 @@ jobs:
           - "15"
           - "16"
           - "17"
-      fail-fast: false
     runs-on: "${{ matrix.runner_image }}"
 
     steps:


### PR DESCRIPTION
it seems that if you build an image for different architectures and on different machines, the last one pushed overwrites the previous one, even if their architecture is different. right now the pipeline on main passed and only the ARM64 versions are present ...

![image](https://github.com/user-attachments/assets/995a304b-d7e7-47a8-bcaa-cbda9329491d)
