### PR TITLE
Add github workflow to build development images for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade'
+        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,69 @@
+name: Build Dev Images
+
+on:
+  # Allow manual trigger
+  workflow_dispatch:
+
+env:
+    # Uses docker.io for Docker Hub if empty
+    REGISTRY: ghcr.io
+    # github.repository as <account>/<repo>
+    IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            matrix:
+                include:
+                  - file: Dockerfile.bookworm
+                    tag_suffix: debian
+                  - file: Dockerfile.alpine
+                    tag_suffix: alpine
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            # Login against a container registry
+            # https://github.com/docker/login-action
+            - name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            # Extract metadata (tags, labels) for container
+            # https://github.com/docker/metadata-action
+            - name: Extract container metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+            # Setup QEMU emulator to build multi-arch images
+            # https://github.com/docker/setup-qemu-action
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            # Configure Buildx for Docker build
+            # https://github.com/docker/setup-buildx-action
+            - name: Set up Buildx
+              id: buildx
+              uses: docker/setup-buildx-action@v3
+
+            # Build and push container images
+            # https://github.com/docker/build-push-action
+            - name: Build and push ${{ matrix.tag_suffix }} image
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  file: ${{ matrix.file }}
+                  push: true
+                  tags: ghcr.io/pgautoupgrade/pgautoupgrade:${{ github.ref_name }}-${{ matrix.tag_suffix }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  platforms: linux/amd64,linux/arm64

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -59,11 +59,17 @@ jobs:
             # Build and push container images
             # https://github.com/docker/build-push-action
             - name: Build and push ${{ matrix.tag_suffix }} image
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
+              env:
+                BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+                HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }} 
               with:
                   context: .
                   file: ${{ matrix.file }}
                   push: true
-                  tags: ghcr.io/pgautoupgrade/pgautoupgrade:${{ github.ref_name }}-${{ matrix.tag_suffix }}
+                  # ghcr.io/${{ github.repository }} not used, to match dockerhub image naming
+                  tags: |
+                    ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.BRANCH_NAME }}-${{ matrix.tag_suffix }}
+                    ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.HEAD_SHA }}-${{ matrix.tag_suffix }}
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ use PostgreSQL 17 you can use:
 
     pgautoupgrade/pgautoupgrade:17-alpine
 
+> [!NOTE]  
+> The images available in Github Container Registry are for debugging
+> purposes only. They are built from specific code branches for easier
+> distribution and testing of fixes.
+
 ### Debian vs Alpine based images
 
 The default official Docker PostgreSQL image is Debian Linux


### PR DESCRIPTION
## Issue

- Related to internal discussions, where we thought it might be useful to build images for testing.
- For example, @andyundso was testing a fix with a user: it would be much simpler to ask them to pull and test a pre-built image.
- We agreed it would be good to have these dev images on Github Container Registry, to avoid polluting the dockerhub entry (plus they can be wiped over time with minimal consequence).

## This PR

- Includes a workflow to build images on `workflow_dispatch`, i.e. when a developer triggers a built for a specific branch.
- This will build and publish an image in GHCR, tagged with the branch information.
- As per, https://github.com/docker/metadata-action?tab=readme-ov-file#usage, this will simply be in the format: `ghcr.io/pgautoupgrade/docker-pgautoupgrade:branch_name-debian/alpine`.
- The build is also multi-architecture, in case the tester / user is using AMD64 arch.
- And it builds two images, for both Debian and Alpine based tests.

Let me know if this is suitable / requested changes!

> [!NOTE]  
> Originally I had the tagging done automatically, but I updated to match the Docker Hub entry.
> `pgautoupgrade/pgautoupgrade:branch_name-debian`
> `pgautoupgrade/pgautoupgrade:branch_name-alpine`
> Using the matrix strategy in Github workflows - haven't used this specific feature before, so let me know if it's all good!
