### PR TITLE
Use Ubuntu 22.04 for dev image builds due to segfault on ubuntu-latest

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         permissions:
             contents: read
             packages: write


### PR DESCRIPTION
Follow on from #94
And discussions in #92

Seems like 24.04 is causing a segmentation fault for the Alpine builds, and possibly similar for Debian (hard to identify).

Based on previous image deprecations on the [runner-images repo](https://github.com/actions/runner-images), Github seem to match their deprecation with end of standard support for the Ubuntu version. With this in mind 22.04 should hopefully **last until Apr 2027**.

We can test 24.04 at intervals and hopefully get it to work in future 🙏 

**Additional context**

- The ci.yml workflow for dockerhub image builds was also downgraded from 24.04 --> 22.04 in commit f4d9878326ac97261558f4b5a9bc0fc11e0cce15