### PR TITLE
Try to read Postgres DB and username from secret files

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -19,10 +19,10 @@ jobs:
         strategy:
             matrix:
                 include:
-                  - file: Dockerfile.bookworm
-                    tag_suffix: debian
-                  - file: Dockerfile.alpine
-                    tag_suffix: alpine
+                    - flavor: "alpine"
+                      alias: "alpine"
+                    - flavor: "bookworm"
+                      alias: "debian"
 
         steps:
             - name: Checkout repository
@@ -62,14 +62,27 @@ jobs:
               uses: docker/build-push-action@v6
               env:
                 BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-                HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }} 
+                HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
               with:
                   context: .
-                  file: ${{ matrix.file }}
+                  file: "Dockerfile.${{ matrix.flavor }}"
                   push: true
                   # ghcr.io/${{ github.repository }} not used, to match dockerhub image naming
                   tags: |
-                    ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.BRANCH_NAME }}-${{ matrix.tag_suffix }}
-                    ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.HEAD_SHA }}-${{ matrix.tag_suffix }}
+                    ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.BRANCH_NAME }}-${{ matrix.alias }}
+                    ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.HEAD_SHA }}-${{ matrix.alias }}
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: linux/amd64,linux/arm64
+                  cache-to: type=inline
+                  cache-from: |
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-9.5-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-9.6-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-10-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-11-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-12-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-13-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-14-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-15-${{ matrix.flavor }}
+                    type=registry,ref=pgautoupgrade/pgautoupgrade:build-16-${{ matrix.flavor }}
+                    type=registry,ref=ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.BRANCH_NAME }}-${{ matrix.alias }}
+                    type=registry,ref=ghcr.io/pgautoupgrade/pgautoupgrade:${{ env.HEAD_SHA }}-${{ matrix.alias }}

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -33,7 +33,7 @@ WORKDIR ${BUILD_ROOT}
 
 # Install things needed for development
 RUN apt update && \
-  apt upgrade && \
+  apt upgrade -y && \
   apt install -y build-essential libicu-dev liblz4-dev locales tzdata zlib1g-dev libzstd-dev wget pkg-config && \
   apt clean
 

--- a/pgautoupgrade-healthcheck.sh
+++ b/pgautoupgrade-healthcheck.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+read_env_or_file() {
+    local var_name="$1"
+    local file_var_name="${var_name}_FILE"
+
+    # Check if the *_FILE environment variable is set and points to a valid file
+    if [[ -n "${!file_var_name}" && -f "${!file_var_name}" && -s "${!file_var_name}" ]]; then
+        # Read the content of the file and assign it to the variable
+        echo "$(cat "${!file_var_name}")"
+    else
+        # Fallback to the normal environment variable
+        echo "${!var_name}"
+    fi
+}
+
 # Define the path to the upgrade lock file using PGDATA if set, otherwise default
 UPGRADE_LOCK_FILE="${PGDATA:-/var/lib/postgresql/data}/upgrade_in_progress.lock"
 
@@ -8,7 +22,10 @@ if [ -f "$UPGRADE_LOCK_FILE" ]; then
     exit 0
 fi
 
-pg_isready -d "${POSTGRES_DB}" -U "${POSTGRES_USER}"
+POSTGRES_DB_VALUE=$(read_env_or_file "POSTGRES_DB")
+POSTGRES_USER_VALUE=$(read_env_or_file "POSTGRES_USER")
+
+pg_isready -d "${POSTGRES_DB_VALUE}" -U "${POSTGRES_USER_VALUE}"
 
 # Capture the exit status of pg_isready
 PG_ISREADY_STATUS=$?


### PR DESCRIPTION
This PR adds support to read the Postgres DB and username from files in our healthcheck. This is common when running Docker Swarm, where the secret values are written into a file.

@spwoodcock I also added caching to the dev build workflow, would you mind to look over those changes?