### PR TITLE
Drop support for PG v12 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
           - flavor: "bookworm"
             alias: "debian"
         pg_target:
-          - "12"
           - "13"
           - "14"
           - "15"


### PR DESCRIPTION
Of course, you can still upgrade from v12, but no longer to v12 (with our image at least) :)