### PR TITLE
Generate Docker tags using Docker meta action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     - cron: "0 0 * * 0"
 
 env:
-  LATEST_POSTGRES_VERSION: "17"
+  # renovate: datasource=repology depName=homebrew/postgresql@17 versioning=loose
+  LATEST_POSTGRES_VERSION: "17.5"
 
 jobs:
   base-images:
@@ -50,7 +51,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |
-            "PGTARGET=16"
+            "PGTARGET=${{ env.LATEST_POSTGRES_VERSION }}"
           target: "build-${{ matrix.pg_version }}"
           tags: "pgautoupgrade/pgautoupgrade:build-${{ matrix.pg_version }}-${{ matrix.flavor }}"
           cache-to: type=inline
@@ -74,9 +75,9 @@ jobs:
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-14-${{ matrix.operating_system.flavor }}
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-15-${{ matrix.operating_system.flavor }}
         type=registry,ref=pgautoupgrade/pgautoupgrade:build-16-${{ matrix.operating_system.flavor }}
-        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}
-        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}
-        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.alias }}
+        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target.PG_VERSION }}-${{ matrix.operating_system.flavor }}
+        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target.PG_VERSION }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}
+        type=registry,ref=pgautoupgrade/pgautoupgrade:${{ matrix.pg_target.PG_VERSION }}-${{ matrix.operating_system.alias }}
 
     strategy:
       matrix:
@@ -88,11 +89,16 @@ jobs:
           - flavor: "bookworm"
             alias: "debian"
         pg_target:
-          - "13"
-          - "14"
-          - "15"
-          - "16"
-          - "17"
+          # renovate: datasource=repology depName=homebrew/postgresql@13 versioning=loose
+          - PG_VERSION: "13.21"
+          # renovate: datasource=repology depName=homebrew/postgresql@14 versioning=loose
+          - PG_VERSION: "14.18"
+          # renovate: datasource=repology depName=homebrew/postgresql@15 versioning=loose
+          - PG_VERSION: "15.13"
+          # renovate: datasource=repology depName=homebrew/postgresql@16 versioning=loose
+          - PG_VERSION: "16.9"
+          # renovate: datasource=repology depName=homebrew/postgresql@17 versioning=loose
+          - PG_VERSION: "17.5"
 
     steps:
       - name: Set up QEMU
@@ -108,17 +114,32 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: pgautoupgrade/pgautoupgrade
+          flavor: |
+            latest=false
+          # add a .0 to each Postgres version so it is compliant with semantic version
+          # note that the .0 never ends up on an actual tag
+          tags: |
+            type=semver,pattern={{major}},value=${{ matrix.pg_target.PG_VERSION }}.0,suffix=-${{ matrix.operating_system.flavor }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ matrix.pg_target.PG_VERSION }}.0,suffix=-${{ matrix.operating_system.flavor }}
+            type=semver,pattern={{major}},value=${{ matrix.pg_target.PG_VERSION }}.0,suffix=-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ matrix.pg_target.PG_VERSION }}.0,suffix=-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}
+            type=semver,pattern={{major}},value=${{ matrix.pg_target.PG_VERSION }}.0,suffix=-${{ matrix.operating_system.alias }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ matrix.pg_target.PG_VERSION }}.0,suffix=-${{ matrix.operating_system.alias }}
+
       - name: Build image
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
           load: true
-          tags: |
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.alias }}"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            "PGTARGET=${{ matrix.pg_target }}"
+            "PGTARGET=${{ matrix.pg_target.PG_VERSION }}"
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"
 
@@ -129,7 +150,7 @@ jobs:
         run: |
           make test
         env:
-          PGTARGET: ${{ matrix.pg_target }}
+          PGTARGET: ${{ matrix.pg_target.PG_VERSION }}
           OS_FLAVOR: ${{ matrix.operating_system.flavor }}
 
       # otherwise, we run into space problems
@@ -147,18 +168,16 @@ jobs:
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
           platforms: linux/amd64,linux/arm64
-          tags: |
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}"
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.flavor }}${{ matrix.operating_system.OS_VERSION }}"
-            "pgautoupgrade/pgautoupgrade:${{ matrix.pg_target }}-${{ matrix.operating_system.alias }}"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            "PGTARGET=${{ matrix.pg_target }}"
+            "PGTARGET=${{ matrix.pg_target.PG_VERSION }}"
           push: true
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"
 
       - name: Push latest image for each supported OS
-        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main' && matrix.pg_target == env.LATEST_POSTGRES_VERSION
+        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main' && matrix.pg_target.PG_VERSION == env.LATEST_POSTGRES_VERSION
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
@@ -167,13 +186,13 @@ jobs:
             "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.flavor }}"
             "pgautoupgrade/pgautoupgrade:${{ matrix.operating_system.alias }}"
           build-args: |
-            "PGTARGET=${{ matrix.pg_target }}"
+            "PGTARGET=${{ matrix.pg_target.PG_VERSION }}"
           push: true
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"
 
       - name: Push general latest image
-        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main' && matrix.pg_target == env.LATEST_POSTGRES_VERSION && matrix.operating_system.flavor == 'alpine'
+        if: github.repository == 'pgautoupgrade/docker-pgautoupgrade' && github.ref == 'refs/heads/main' && matrix.pg_target.PG_VERSION == env.LATEST_POSTGRES_VERSION && matrix.operating_system.flavor == 'alpine'
         uses: docker/build-push-action@v6
         with:
           file: "Dockerfile.${{ matrix.operating_system.flavor }}"
@@ -181,7 +200,7 @@ jobs:
           tags: |
             "pgautoupgrade/pgautoupgrade:latest"
           build-args: |
-            "PGTARGET=${{ matrix.pg_target }}"
+            "PGTARGET=${{ matrix.pg_target.PG_VERSION }}"
           push: true
           cache-to: type=inline
           cache-from: "${{ env.CACHE_FROM }}"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,5 @@
-ARG PGTARGET=17
+# renovate: datasource=repology depName=homebrew/postgresql@17 versioning=loose
+ARG PGTARGET=17.5
 
 # renovate: datasource=docker depName=alpine versioning=loose
 ARG ALPINE_VERSION=3.22
@@ -170,11 +171,10 @@ COPY --from=build-15 /usr/local-pg15 /usr/local-pg15
 COPY --from=build-16 /usr/local-pg16 /usr/local-pg16
 
 # Remove any left over PG directory stubs.  Doesn't help with image size, just with clarity on what's in the image.
-RUN if [ "${PGTARGET}" -eq 12 ]; then rm -rf /usr/local-pg12 /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 13 ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 14 ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 15 ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 16 ]; then rm -rf /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG13_VERSION}" ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG14_VERSION}" ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG15_VERSION}" ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG16_VERSION}" ]; then rm -rf /usr/local-pg16; fi
 
 # Install locale
 RUN apk update && \

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -1,4 +1,5 @@
-ARG PGTARGET=17
+# renovate: datasource=repology depName=homebrew/postgresql@17 versioning=loose
+ARG PGTARGET=17.5
 
 ### Things we need in all build containers
 FROM debian:bookworm AS base-build
@@ -165,11 +166,10 @@ COPY --from=build-15 /usr/local-pg15 /usr/local-pg15
 COPY --from=build-16 /usr/local-pg16 /usr/local-pg16
 
 # Remove any left over PG directory stubs.  Doesn't help with image size, just with clarity on what's in the image.
-RUN if [ "${PGTARGET}" -eq 12 ]; then rm -rf /usr/local-pg12 /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 13 ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 14 ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 15 ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq 16 ]; then rm -rf /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG13_VERSION}" ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG14_VERSION}" ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG15_VERSION}" ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" -eq "${PG16_VERSION}" ]; then rm -rf /usr/local-pg16; fi
 
 # Install locale
 RUN apt update && \

--- a/postgres-docker-entrypoint.sh
+++ b/postgres-docker-entrypoint.sh
@@ -307,7 +307,7 @@ get_bin_path() {
   if [ -f /etc/alpine-release ]; then
     echo "/usr/local/bin"
   else
-    echo "/usr/lib/postgresql/${PGTARGET}/bin"
+    echo "/usr/lib/postgresql/${PGTARGET%%.*}/bin"
   fi
 }
 
@@ -390,13 +390,15 @@ _main() {
 		echo "************************************"
 
 		# Get the version of the PostgreSQL data files
-		local PGVER=${PGTARGET}
+		local PGVER=${PGTARGET%%.*}
+		local PGTARGET_MAJOR=${PGTARGET%%.*}
+
 		if [ -s "${PGDATA}/PG_VERSION" ]; then
 			PGVER=$(cat "${PGDATA}/PG_VERSION")
 		fi
 
 		# If the version of PostgreSQL data files doesn't match our desired version, then upgrade them
-		if [ "${PGVER}" != "${PGTARGET}" ]; then
+		if [ "${PGVER}" != "${PGTARGET_MAJOR}" ]; then
 			create_upgrade_lock_file
 			# Ensure the database files are a version we can upgrade
 			local RECOGNISED=0
@@ -404,16 +406,16 @@ _main() {
 			if [ "${PGVER}" = "9.5" ] || [ "${PGVER}" = "9.6" ] || [ "${PGVER}" = "10" ] || [ "${PGVER}" = "11" ] || [ "${PGVER}" = "12" ]; then
 				RECOGNISED=1
 			fi
-			if [ "${PGTARGET}" -gt 13 ] && [ "${PGVER}" = "13" ]; then
+			if [ "${PGTARGET_MAJOR}" -gt 13 ] && [ "${PGVER}" = "13" ]; then
 				RECOGNISED=1
 			fi
-			if [ "${PGTARGET}" -gt 14 ] && [ "${PGVER}" = "14" ]; then
+			if [ "${PGTARGET_MAJOR}" -gt 14 ] && [ "${PGVER}" = "14" ]; then
 				RECOGNISED=1
 			fi
-			if [ "${PGTARGET}" -gt 15 ] && [ "${PGVER}" = "15" ]; then
+			if [ "${PGTARGET_MAJOR}" -gt 15 ] && [ "${PGVER}" = "15" ]; then
 				RECOGNISED=1
 			fi
-			if [ "${PGTARGET}" -gt 16 ] && [ "${PGVER}" = "16" ]; then
+			if [ "${PGTARGET_MAJOR}" -gt 16 ] && [ "${PGVER}" = "16" ]; then
 				RECOGNISED=1
 			fi
 			if [ "${RECOGNISED}" -eq 1 ]; then
@@ -641,7 +643,7 @@ _main() {
 				echo "Reindexing the databases"
 				echo "------------------------"
 
-				if [[ "$PGTARGET" -le 15 ]]; then
+				if [[ "$PGTARGET_MAJOR" -le 15 ]]; then
 					reindexdb --all --username="${POSTGRES_USER}"
 				else
 					reindexdb --all --concurrently --username="${POSTGRES_USER}"

--- a/test.sh
+++ b/test.sh
@@ -64,7 +64,7 @@ test_run() {
 
     # Verify the PostgreSQL data files are now the target version
     PGVER=$(sudo cat postgres-data/PG_VERSION)
-    if [ "$PGVER" != "${TARGET}" ]; then
+    if [ "$PGVER" != "${TARGET%%.*}" ]; then
         banner '*' "Standard automatic upgrade of PostgreSQL from version ${VERSION} to ${TARGET} FAILED!"
         FAILURE=1
     else
@@ -92,7 +92,7 @@ test_run() {
 
     # Verify the PostgreSQL data files are now the target version
     PGVER=$(sudo cat postgres-data/PG_VERSION)
-    if [ "$PGVER" != "${TARGET}" ]; then
+    if [ "$PGVER" != "${TARGET%%.*}" ]; then
         banner '*' "'One shot' automatic upgrade of PostgreSQL from version ${VERSION} to ${TARGET} FAILED!"
         FAILURE=1
     else
@@ -128,7 +128,7 @@ tar -xf AdventureWorks.tar.xz
 
 for version in "${PG_VERSIONS[@]}"; do
     # Only test if the version is less than the latest version
-    if [[ $(echo "$version < $PGTARGET" | bc) -eq 1 ]]; then
+    if [[ $(echo "$version < ${PGTARGET%%.*}" | bc) -eq 1 ]]; then
         test_run "$version" "$PGTARGET" "$OS_FLAVOR"
     fi
 done


### PR DESCRIPTION
Closes #124.

This PR adds the minor version of a Postgres release to our Docker tags. It leverages the meta action by Docker, where we have easy template options for the correct version.

Under the hood, we make `PGTARGET` aware of the minor version. There are a few places in the entryscript where have to strip the minor version away again.