### PR TITLE
Use String equality

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -171,10 +171,10 @@ COPY --from=build-15 /usr/local-pg15 /usr/local-pg15
 COPY --from=build-16 /usr/local-pg16 /usr/local-pg16
 
 # Remove any left over PG directory stubs.  Doesn't help with image size, just with clarity on what's in the image.
-RUN if [ "${PGTARGET}" -eq "${PG13_VERSION}" ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq "${PG14_VERSION}" ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq "${PG15_VERSION}" ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq "${PG16_VERSION}" ]; then rm -rf /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG13_VERSION}" ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG14_VERSION}" ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG15_VERSION}" ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG16_VERSION}" ]; then rm -rf /usr/local-pg16; fi
 
 # Install locale
 RUN apk update && \

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -166,10 +166,10 @@ COPY --from=build-15 /usr/local-pg15 /usr/local-pg15
 COPY --from=build-16 /usr/local-pg16 /usr/local-pg16
 
 # Remove any left over PG directory stubs.  Doesn't help with image size, just with clarity on what's in the image.
-RUN if [ "${PGTARGET}" -eq "${PG13_VERSION}" ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq "${PG14_VERSION}" ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq "${PG15_VERSION}" ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
-RUN if [ "${PGTARGET}" -eq "${PG16_VERSION}" ]; then rm -rf /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG13_VERSION}" ]; then rm -rf /usr/local-pg13 /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG14_VERSION}" ]; then rm -rf /usr/local-pg14 /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG15_VERSION}" ]; then rm -rf /usr/local-pg15 /usr/local-pg16; fi
+RUN if [ "${PGTARGET}" == "${PG16_VERSION}" ]; then rm -rf /usr/local-pg16; fi
 
 # Install locale
 RUN apt update && \


### PR DESCRIPTION
#135 worked almost as expected. the correct Docker tags were generated, but the build threw an error because `-eq` does not work. Since `PGTARGET` and `PGXX_VERSION` now contain the minor versions as well, I switch to using string equality to remove the unnecessary upgrade binaries.