### PR TITLE
move create_upgrade_lock_file just before first mutation, fixes #128

### DIFF
--- a/postgres-docker-entrypoint.sh
+++ b/postgres-docker-entrypoint.sh
@@ -399,7 +399,6 @@ _main() {
 
 		# If the version of PostgreSQL data files doesn't match our desired version, then upgrade them
 		if [ "${PGVER}" != "${PGTARGET_MAJOR}" ]; then
-			create_upgrade_lock_file
 			# Ensure the database files are a version we can upgrade
 			local RECOGNISED=0
 			local OLDPATH=unset
@@ -458,6 +457,8 @@ _main() {
 				echo "*******************************************************************************************"
 				exec gosu postgres "$BASH_SOURCE" "$@"
 			fi
+
+			create_upgrade_lock_file
 
 			# Don't automatically abort on non-0 exit status, as that messes with these upcoming mv commands
 			set +e


### PR DESCRIPTION
fixes #128

EDIT: I figured out that it is not specific to Bitnami images, so I adjusted my comment below to use the official postgres images:

As described in #128 when clearing the CMD to let the official postgres image init the database, then we get in a situation where the upgrade is not performed. The lock file gets created before the script switches to the postgres user and thus locks itself with the lock file.

To prevent this the lock file is now created after switching to the postgres user and before doing the first mutation on the database files. This is safe because the lines between the old and new position are just doing some checks but not actually modifying anything. So we can lock at this later position safely.

It would be nice if someone could have a look at this PR. If there is anything to update or change, let me know.