### PR TITLE
adjust message after upgrade step in one shot mode

### DIFF
--- a/postgres-docker-entrypoint.sh
+++ b/postgres-docker-entrypoint.sh
@@ -680,13 +680,19 @@ _main() {
 			sleep 5
 		done
 	else
-		# If no upgrade was performed, then we start PostgreSQL as per normal as long as "one shot" mode wasn't requested
+		# If no upgrade was performed or the upgrade has finished, then we start PostgreSQL as per normal as long as "one shot" mode wasn't requested
 		if [ "x${PGAUTO_ONESHOT}" = "xyes" ]; then
-			echo "***********************************************************************************"
-			echo "'One shot' automatic upgrade was requested, so exiting as there is no upgrade to do"
-			echo "If you're seeing this message and expecting an upgrade to be happening, it probably"
-			echo "means the container is being started in a loop and a previous run already did it :)"
-			echo "***********************************************************************************"
+			if [ "${UPGRADE_PERFORMED}" -eq 1 ]; then
+				echo "**********************************************************************************"
+				echo "'One shot' automatic upgrade was requested, so exiting as the upgrade has finished"
+				echo "**********************************************************************************"
+			else
+				echo "***********************************************************************************"
+				echo "'One shot' automatic upgrade was requested, so exiting as there is no upgrade to do"
+				echo "If you're seeing this message and expecting an upgrade to be happening, it probably"
+				echo "means the container is being started in a loop and a previous run already did it :)"
+				echo "***********************************************************************************"
+			fi
 		else
 			# Start PostgreSQL
 			exec "$@"


### PR DESCRIPTION
Thanks for this nice project. It helps me a lot dealing with my postgres databases. I found a small misleading message during testing, see below:

After PR 'Move postupgrade tasks into main upgrade procedure' #109 the message shown after the upgrade step indicates that there was no upgrade performed even so the upgrade actually was performed. The message is only showing in the 'one shot' mode. The message was some kind of misleading.

The log shows the following:

```

PostgreSQL Database directory appears to contain a database; Skipping initialization

************************************
PostgreSQL data directory: /var/lib/postgresql/data
************************************
Creating upgrade lock file at /var/lib/postgresql/data/upgrade_in_progress.lock
*******************************************************************************************
Performing PG upgrade on version 16 database files.  Upgrading to version 17.5
*******************************************************************************************
...
---------------------------------------
Running pg_upgrade command, from /var/lib/postgresql/data
---------------------------------------
...
--------------------------------------
Running pg_upgrade command is complete
--------------------------------------
...
***************************************************************************************
Automatic upgrade process finished upgrading the data format to PostgreSQL 17.5.
***************************************************************************************
...
------------------------
Reindexing the databases
------------------------
...
-------------------------------
End of reindexing the databases
-------------------------------
...
*******************************************
Upgrade to PostgreSQL 17.5 complete.
*******************************************
Removing upgrade lock file at /var/lib/postgresql/data/upgrade_in_progress.lock
***********************************************************************************
'One shot' automatic upgrade was requested, so exiting as there is no upgrade to do
If you're seeing this message and expecting an upgrade to be happening, it probably
means the container is being started in a loop and a previous run already did it :)
***********************************************************************************
-------------------------------------------------------------------------------
Restoring original data permissions to /var/lib/postgresql/data
-------------------------------------------------------------------------------
```

The log indicates the the upgrade was performed, but the message `'One shot' automatic upgrade was requested, so exiting as there is no upgrade to do` indicates that there was no upgrade.

When merging this PR the message will change to this (only when the upgrade was performed):

```
**********************************************************************************
'One shot' automatic upgrade was requested, so exiting as the upgrade has finished
**********************************************************************************
```

It would be nice if someone could have a look at this PR. If there is anything to update or change, let me know. If you do not want to change this, just close this PR.