### PR TITLE
Reformat list to please Renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,16 +89,16 @@ jobs:
           - flavor: "bookworm"
             alias: "debian"
         pg_target:
-          # renovate: datasource=repology depName=homebrew/postgresql@13 versioning=loose
-          - PG_VERSION: "13.21"
-          # renovate: datasource=repology depName=homebrew/postgresql@14 versioning=loose
-          - PG_VERSION: "14.18"
-          # renovate: datasource=repology depName=homebrew/postgresql@15 versioning=loose
-          - PG_VERSION: "15.13"
-          # renovate: datasource=repology depName=homebrew/postgresql@16 versioning=loose
-          - PG_VERSION: "16.9"
-          # renovate: datasource=repology depName=homebrew/postgresql@17 versioning=loose
-          - PG_VERSION: "17.5"
+          - # renovate: datasource=repology depName=homebrew/postgresql@13 versioning=loose
+            PG_VERSION: "13.21"
+          - # renovate: datasource=repology depName=homebrew/postgresql@14 versioning=loose
+            PG_VERSION: "14.18"
+          - # renovate: datasource=repology depName=homebrew/postgresql@15 versioning=loose
+            PG_VERSION: "15.13"
+          - # renovate: datasource=repology depName=homebrew/postgresql@16 versioning=loose
+            PG_VERSION: "16.9"
+          - # renovate: datasource=repology depName=homebrew/postgresql@17 versioning=loose
+            PG_VERSION: "17.5"
 
     steps:
       - name: Set up QEMU


### PR DESCRIPTION
The custom manager by Renovate we use to update versions in the `ci.yml` file does not support having a `-` between the magic comment for Renovate and the `XXX_VERSION` statement. When we reformat our list a little bit, then it should work.

Regex can be viewed [here](https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions).