### PR TITLE
Update to Trixie

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 test
 
 Dockerfile.alpine
-Dockerfile.bookworm
+Dockerfile.trixie

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         flavor:
           - alpine
-          - bookworm
+          - trixie
         pg_version:
           - "9.5"
           - "9.6"
@@ -86,7 +86,7 @@ jobs:
             # renovate: datasource=docker depName=alpine versioning=docker
             OS_VERSION: "3.22"
             alias: "alpine"
-          - flavor: "bookworm"
+          - flavor: "trixie"
             alias: "debian"
         pg_target:
           - # renovate: datasource=repology depName=homebrew/postgresql@13 versioning=loose

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -21,7 +21,7 @@ jobs:
                 include:
                     - flavor: "alpine"
                       alias: "alpine"
-                    - flavor: "bookworm"
+                    - flavor: "trixie"
                       alias: "debian"
 
         steps:

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -2,7 +2,7 @@
 ARG PGTARGET=17.5
 
 ### Things we need in all build containers
-FROM debian:bookworm AS base-build
+FROM debian:trixie AS base-build
 
 # The versions of PostgreSQL to use
 ENV PG95=9.5.25
@@ -142,8 +142,8 @@ RUN cd postgresql-16.* && \
   make install-world && \
   rm -rf /usr/local-pg16/include
 
-# Use the PostgreSQL Bookworm image as our output image base
-FROM postgres:${PGTARGET}-bookworm
+# Use the PostgreSQL Trixie image as our output image base
+FROM postgres:${PGTARGET}-trixie
 
 # Copy default configuration in case the original container does not provide it (Bitnami ...)
 RUN mkdir -p /opt/pgautoupgrade && \

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ based, and upgrading from that to one of our Alpine Linux
 based images doesn't always work out well.
 
 To solve that problem, we have Debian based images
-(`17-bookworm` and `16-bookworm`) available now as well.
+(`17-trixie` and `16-trixie`) available as well.
 
 To use either of those, choose the version of PostgreSQL you'd
 like to upgrade to, then change your docker image to match:
 
-    pgautoupgrade/pgautoupgrade:17-bookworm
+    pgautoupgrade/pgautoupgrade:17-trixie
 
 ### "One shot" mode
 
@@ -121,21 +121,21 @@ You can run `pgautoupgrade` as an `initContainer` in Kubernetes to enable one-sh
 ```yaml
 initContainers:
 - env:
-	- name: PGAUTO_ONESHOT
-	  value: "yes"
-	- name: POSTGRES_DB
-	  value: XXX
-	- name: PGDATA
-	  value: /bitnami/postgresql/data
-	- name: POSTGRES_PASSWORD
-	  value: password
-image: pgautoupgrade/pgautoupgrade:17-bookworm
+  - name: PGAUTO_ONESHOT
+    value: "yes"
+  - name: POSTGRES_DB
+    value: XXX
+  - name: PGDATA
+    value: /bitnami/postgresql/data
+  - name: POSTGRES_PASSWORD
+    value: password
+image: pgautoupgrade/pgautoupgrade:17-trixie
 name: upgrade-postgres
 securityContext:
-	runAsUser: 0
+  runAsUser: 0
 volumeMounts:
-	- mountPath: /bitnami/postgresql
-	  name: YYY
+  - mountPath: /bitnami/postgresql
+    name: YYY
 ```
 
 The value for `POSTGRES_PASSWORD` does not really matter, as it's never used in one-shot mode.


### PR DESCRIPTION
With this PR, we move from Debian 12 to Debian 13 for the Debian-based builds.