### PR TITLE
Ensure process to wait on actually quit

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -67,8 +67,14 @@ trap 'forward_signal QUIT' QUIT
 set +e
 
 # wait for the child process to exit
+# if we get SIGINT or SIGTERM, then it will terminate the first "wait" but the PG process is still running
+# therefore, we look up if the process still runs and if so, wait again
 wait "$pid"
 exit_code=$?
+if kill -0 "$pid" 2>/dev/null; then
+    wait "$pid"
+    exit_code=$?
+fi
 
 if [[ "x${PGAUTO_ONESHOT}" = "xyes" && $POSTGRESQL_DATA_DIRECTORY_HAS_DATA = 1 ]]; then
     if [ "$EXISTING_POSTGRESQL_CONF" = "0" ]; then


### PR DESCRIPTION
Closes #121

It seems that our `wait` statement returns early when the signal from Docker is received. This usually means the last checkpoint by Postgres is not written correctly, and a recovery has to be done at the next start.

I first checked if the PID that the bash script stores is the same as the Postgres process, which seems to be the case. So this commit adds a second check if the PID is still alive (despite `wait` returning) and will `wait` a second time. This seems to fix the issue, as the second `wait` only returns when the Postgres process actually terminates.