### PR TITLE
Fix flaky tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -79,6 +79,7 @@ test_run() {
     PGVER=$(sudo cat $PGVERSION_FILE)
     if [ "$PGVER" != "${TARGET%%.*}" ]; then
         banner '*' "Standard automatic upgrade of PostgreSQL from version ${VERSION} to ${TARGET} FAILED!"
+        docker logs test-postgres-1
         FAILURE=1
     else
         banner '*' "Standard automatic upgrade of PostgreSQL from version ${VERSION} to ${TARGET} SUCCEEDED!"
@@ -86,6 +87,7 @@ test_run() {
 
     if ! docker compose -f $PGAUTO_COMPOSE exec postgres psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='AdventureWorks'" | grep -q 1; then
         banner "Adventure works database does not exist in new PostgreSQL container - upgrade did not work!"
+        docker logs test-postgres-1
         FAILURE=1
     fi
 

--- a/test/docker-compose-pgauto.yml
+++ b/test/docker-compose-pgauto.yml
@@ -6,7 +6,7 @@ services:
       - ./postgres-data:/var/lib/postgresql/data
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/test/docker-compose-pgauto18.yml
+++ b/test/docker-compose-pgauto18.yml
@@ -6,7 +6,7 @@ services:
       - ./postgres-data:/var/lib/postgresql
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This PR should hopefully fix our flaky tests on CI.

I added an instruction that when the tests fail in detached mode, the Docker logs are printed, giving us something to work with. From that I discovered that the `pg_isready` check has a chance to return too early. When reindexing the databases, a temporary server is started that is only available through the UNIX socket, so that no external clients will connect. However, `pg_isready` can also connect to that socket, resulting in it sometimes marking the container as healthy even though the upgrade was still running. And then, when we executed a second check, the Postgres server was shutdown, resulting in the test failure.